### PR TITLE
CMake Find Modules and Minor Cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,21 @@
 cmake_minimum_required(VERSION 3.10)
 project(amcpp CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+
 enable_testing()
 include(CTest)
 
+find_package(MSGSL REQUIRED)
+find_package(Sanitizer COMPONENTS address undefined)
+
 function(build file)
    set(target "amcpp.${file}")
-   add_executable("${target}" "${file}.cpp")
-   target_compile_options("${target}" PUBLIC
+   add_executable(${target} "${file}.cpp")
+   target_compile_options(${target} PUBLIC
       -Wall
       -Wextra
       -Wno-attributes
@@ -38,40 +46,15 @@ function(build file)
       -Werror
       -fdiagnostics-color=always
       $<$<CONFIG:Debug>:
-         -O0
-         -g3
-         -fno-inline
-         -fstack-protector-all
-         -fno-omit-frame-pointer
-         -fno-optimize-sibling-calls>
-      $<$<CONFIG:Release>:
-         -O3
-         -g0
-         -DNDEBUG>
-      $<$<CONFIG:MinSizeRel>:
-         -Os
-         -g0
-         -DNDEBUG>
-      $<$<CONFIG:RelWithDebInfo>:
-         -O3
-         -g3
-         -DNDEBUG>)
-   if (NOT WIN32)
-      target_compile_options("${target}" PUBLIC
-         $<$<CONFIG:Debug>:
-            -fsanitize=address
-            -fsanitize=undefined>
-         $<$<CONFIG:RelWithDebInfo>:
-            -fsanitize=address
-            -fsanitize=undefined>)
-   endif()
-   target_compile_definitions("${target}" PUBLIC
-      $<$<CONFIG:Release>: NDEBUG>
-      $<$<CONFIG:MinSizeRel>: NDEBUG>)
-   target_compile_features("${target}" PUBLIC cxx_std_17)
+         -fstack-protector-all>)
+   target_link_libraries(${target} PUBLIC
+      $<$<CONFIG:Debug>:Sanitizer::all>
+      $<$<CONFIG:RelWithDebInfo>:Sanitizer::all>)
+   target_compile_features(${target} PUBLIC cxx_std_17)
+   target_link_libraries(${target} PUBLIC MSGSL::gsl)
+   target_include_directories(${target} PUBLIC "${PROJECT_SOURCE_DIR}/include")
 endfunction()
 
-include_directories(include)
 add_subdirectory(00-hello-world)
 add_subdirectory(01-types)
 add_subdirectory(02-computation)

--- a/cmake/FindMSGSL.cmake
+++ b/cmake/FindMSGSL.cmake
@@ -1,0 +1,15 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(MSGSL_INCLUDE_DIRS gsl/gsl)
+
+find_package_handle_standard_args(MSGSL
+    REQUIRED_VARS MSGSL_INCLUDE_DIRS)
+
+if(TARGET MSGSL::gsl)
+    return()
+endif()
+
+add_library(MSGSL::gsl INTERFACE IMPORTED)
+set_target_properties(MSGSL::gsl PROPERTIES
+	INTERFACE_INCLUDE_DIRECTORIES ${MSGSL_INCLUDE_DIRS}
+	INTERFACE_COMPILE_FEATURES cxx_std_11)

--- a/cmake/FindSanitizer.cmake
+++ b/cmake/FindSanitizer.cmake
@@ -1,0 +1,31 @@
+include(FindPackageHandleStandardArgs)
+include(CheckCXXCompilerFlag)
+include(CMakePushCheckState)
+
+add_library(Sanitizer::all INTERFACE IMPORTED)
+set(Sanitizer_FOUND ON)
+
+foreach(san ${Sanitizer_FIND_COMPONENTS})
+    if(TARGET Sanitizer::${san})
+        continue()
+    endif()
+
+    cmake_push_check_state(RESET)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES -fsanitize=${san})
+    check_cxx_compiler_flag(-fsanitize=${san} ${san}_sanitizer_supported)
+    cmake_pop_check_state()
+    
+    if(${${san}_sanitizer_supported})
+        add_library(Sanitizer::${san} INTERFACE IMPORTED)
+        set_target_properties(Sanitizer::${san} PROPERTIES
+                              INTERFACE_COMPILE_OPTIONS -fsanitize=${san}
+                              INTERFACE_LINK_LIBRARIES -fsanitize=${san})
+        set(Sanitizer_${san}_FOUND TRUE)
+        set_property(TARGET Sanitizer::all APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES Sanitizer::${san})
+    endif()
+endforeach()
+
+find_package_handle_standard_args(Sanitizer 
+    REQUIRED_VARS Sanitizer_FOUND
+    HANDLE_COMPONENTS)


### PR DESCRIPTION
Added CMake Modules for GSL and Sanitizers
Removed some unneccessary compiler flags in root CMakeLists
Enabled LTO on Release, disabled language extensions